### PR TITLE
Update scraper script and automate aggregation

### DIFF
--- a/scrape_data/combine_daily_files.py
+++ b/scrape_data/combine_daily_files.py
@@ -1,0 +1,88 @@
+import os
+import logging
+
+import boto3
+import json
+import pandas as pd
+import pendulum
+
+# use for dev, but don't deploy to Lambda:
+# from dotenv import load_dotenv
+# load_dotenv()
+
+BUCKET_PRIVATE = os.getenv('BUCKET_PRIVATE')
+BUCKET_PUBLIC = os.getenv('BUCKET_PUBLIC')
+
+logger = logging.getLogger()
+logging.basicConfig(level=logging.INFO)
+
+
+def combine_daily_files(
+    date: str
+):
+    """Combine raw JSON files returned by API into daily CSVs. 
+
+    Args:
+        date: Date string for which raw JSON files should be combined into CSVs.
+    """
+    s3 = boto3.resource("s3")
+
+    for bucket_name in [BUCKET_PRIVATE, BUCKET_PUBLIC]:
+        bucket = s3.Bucket(bucket_name)
+        objects = bucket.objects.filter(Prefix=f"bus_data/{date}")
+
+        # load data
+        data_dict = {}
+
+        for obj in objects:
+            obj_name = obj.key
+            # https://stackoverflow.com/questions/31976273/open-s3-object-as-a-string-with-boto3
+            obj_body = json.loads(obj.get()["Body"].read().decode("utf-8"))
+            data_dict[obj_name] = obj_body
+
+            data = pd.DataFrame()
+            errors = pd.DataFrame()
+
+            # k, v here are filename, full dict of JSON
+            for k, v in data_dict.items():
+                filename = k
+                new_data = pd.DataFrame()
+                new_errors = pd.DataFrame()
+                # expect ~12 "chunks" per JSON
+                for chunk, contents in v.items():
+                    if "vehicle" in v[chunk]["bustime-response"].keys():
+                        new_data = new_data.append(
+                            pd.DataFrame(v[chunk]["bustime-response"]["vehicle"])
+                        )
+                    if "error" in v[chunk]["bustime-response"].keys():
+                        new_errors = new_errors.append(
+                            pd.DataFrame(v[chunk]["bustime-response"]["error"])
+                        )
+                new_data["scrape_file"] = filename
+                new_errors["scrape_file"] = filename
+                data = data.append(new_data)
+                errors = errors.append(new_errors)
+
+            if len(errors) > 0:
+                bucket.put_object(
+                    Body=errors.to_csv(index=False),
+                    Key=f"bus_full_day_errors_v2/{date}.csv",
+                )
+
+            if len(data) > 0:
+                # convert data time to actual datetime
+                data["data_time"] = pd.to_datetime(
+                    data["tmstmp"], format="%Y%m%d %H:%M")
+
+                data["data_hour"] = data.data_time.dt.hour
+                data["data_date"] = data.data_time.dt.date
+
+                bucket.put_object(
+                    Body=data.to_csv(index=False),
+                    Key=f"bus_full_day_data_v2/{date}.csv",
+                )
+
+
+def lambda_handler(event, context):
+    date = pendulum.yesterday("America/Chicago").to_date_string()
+    combine_daily_files(date)

--- a/scrape_data/combine_daily_files.py
+++ b/scrape_data/combine_daily_files.py
@@ -24,7 +24,7 @@ def combine_daily_files(date: str):
     """Combine raw JSON files returned by API into daily CSVs. 
 
     Args:
-        date: Date string for which raw JSON files should be combined into CSVs.
+        date: Date string for which raw JSON files should be combined into CSVs. Format: YYYY-MM-DD.
     """
     s3 = boto3.resource("s3")
 

--- a/scrape_data/scrape_data.py
+++ b/scrape_data/scrape_data.py
@@ -15,8 +15,9 @@ import requests
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-BUCKET_PRIVATE = os.getenv('BUCKET_PRIVATE', 'chn-ghost-buses-private')
-BUCKET_PUBLIC = os.getenv('BUCKET_PUBLIC', 'chn-ghost-buses-public')
+BUCKET_PRIVATE = os.getenv("BUCKET_PRIVATE", "chn-ghost-buses-private")
+BUCKET_PUBLIC = os.getenv("BUCKET_PUBLIC", "chn-ghost-buses-public")
+
 
 def scrape(routes_df, url):
     bus_routes = routes_df[routes_df.route_type == 3]
@@ -29,10 +30,7 @@ def scrape(routes_df, url):
         logger.info(f"Requesting routes: {route_query_string}")
         try:
             chunk_response = json.loads(
-                requests.get(
-                    url +
-                    f"&rt={route_query_string}" +
-                    "&format=json").text
+                requests.get(url + f"&rt={route_query_string}" + "&format=json").text
             )
             response_json[f"chunk_{chunk}"] = chunk_response
         except requests.RequestException as e:
@@ -46,7 +44,7 @@ def lambda_handler(event, context):
     API_KEY = os.environ.get("CHN_GHOST_BUS_CTA_BUS_TRACKER_API_KEY")
     s3 = boto3.client("s3")
     # tuple of the form: (version label as used in URL, version label to append to top-level directory name)
-    for api_version in [('v2', ''), ('v3', '_v3')]:
+    for api_version in [("v2", ""), ("v3", "_v3")]:
         logger.info(f"Hitting API version {api_version[0]}")
         api_url = (
             f"http://www.ctabustracker.com/bustime/api"

--- a/scrape_data/scrape_data.py
+++ b/scrape_data/scrape_data.py
@@ -47,6 +47,7 @@ def lambda_handler(event, context):
     s3 = boto3.client("s3")
     # tuple of the form: (version label as used in URL, version label to append to top-level directory name)
     for api_version in [('v2', ''), ('v3', '_v3')]:
+        logger.info(f"Hitting API version {api_version[0]}")
         api_url = (
             f"http://www.ctabustracker.com/bustime/api"
             f"/{api_version[0]}/getvehicles?key={API_KEY}"
@@ -60,8 +61,10 @@ def lambda_handler(event, context):
         logger.info("Saving data")
         t = pendulum.now("America/Chicago")
         for bucket in [BUCKET_PUBLIC, BUCKET_PRIVATE]:
+            key = f"bus_data{api_version[1]}/{t.to_date_string()}/{t.to_time_string()}.json"
+            logger.info(f"Writing to {key}")
             s3.put_object(
                 Bucket=bucket,
-                Key=f"bus_data{api_version[1]}/{t.to_date_string()}/{t.to_time_string()}.json",
+                Key=key,
                 Body=data,
             )


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

*Should merge after #8*

# Description

This PR:

- [x] Updates the scraper script to write to both the public & private buckets (so data is more accessible but we still have a backup)
- [x] Updates the scraper script to hit v3 of the CTA API so we can compare the results between the two
- [x] Automates the creation of the daily aggregations 

After this is merged, will need to take the steps outlined in #17

Resolves #10, resolves #9 

## Type of change

- [ ] Bug fix
- [x] New functionality
- [ ] Documentation

## How has this been tested?
I have done Lambda test runs for the new scraper & aggregator & verified that they appear to run as expected. 