### PR TITLE
Add options for custom aggregation frequencies

### DIFF
--- a/data_analysis/static_gtfs_analysis.py
+++ b/data_analysis/static_gtfs_analysis.py
@@ -59,7 +59,7 @@ class GTFSFeed:
             GTFSFeed: A GTFSFeed object containing multiple DataFrames
                 accessible by name.
         """
-        logging.info(f"Extracting data from {gtfs_zipfile}")
+        logging.info(f"Extracting data from CTA zipfile version {VERSION_ID}")
         data_dict = {}
         pbar = tqdm(cls.__annotations__.keys())
         for txt_file in pbar:
@@ -219,9 +219,9 @@ def make_trip_summary(data: GTFSFeed) -> pd.DataFrame:
         service_happened, how="left", on="service_id")
 
     # get only the trip / hour combos that actually occurred
-    trip_stop_hours = data.stop_times[[
-        "trip_id", "arrival_hour"]].drop_duplicates()
-
+    trip_stop_hours = data.stop_times.drop_duplicates(
+        ["trip_id", "arrival_hour"]
+    )
     # now join
     # result has one row per date + row from trips.txt (incl. route) + hour
     trip_summary = trips_happened.merge(
@@ -230,68 +230,99 @@ def make_trip_summary(data: GTFSFeed) -> pd.DataFrame:
     return trip_summary
 
 
+def group_trips(trip_summary: pd.DataFrame, groupby_vars: list, hourly: bool):
+    trip_summary = trip_summary.copy()
+    summary = (
+        trip_summary.groupby(by=groupby_vars)
+        ["trip_id"]
+        .count()
+        .reset_index()
+    )
+
+    if hourly:
+        summary.rename(
+            columns={
+                "arrival_hour": "hour",
+                "trip_id": "trip_count",
+                "raw_date": "date"},
+            inplace=True,
+        )
+
+    else:
+        summary.rename(
+            columns={
+                "trip_id": "trip_count",
+                "raw_date": "date"},
+            inplace=True
+        )
+    summary.date = summary.date.dt.date
+    return summary
+
+
 def summarize_and_save(trip_summary: pd.DataFrame,
+                       hourly: bool = True,
                        save: bool = True) -> pd.DataFrame:
     """Get trips by hour, date, and route
 
     Args:
         trip_summary (pd.DataFrame): a summary of trips with one row per date.
             Output of the make_trip_summary function.
+        hourly: (bool, optional): whether to aggregate by arrival_hour.
+            Defaults to True.
         save (bool, optional): whether to save to S3 bucket. Defaults to True.
 
     Returns:
-        pd.DataFrame: A DataFrame grouped by date, hour, route, and direction.
+        pd.DataFrame: A DataFrame grouped by date, hour, and route
     """
-    # now group to get trips by hour by date by route
-    route_daily_hourly_summary = (
-        trip_summary.groupby(by=["raw_date", "route_id", "arrival_hour"])
-        ["trip_id"]
-        .count()
-        .reset_index()
-    )
+    trip_summary = trip_summary.copy()
+    groupby_vars = ["raw_date", "route_id"]
 
-    route_daily_hourly_summary.rename(
-        columns={
-            "arrival_hour": "hour",
-            "trip_id": "trip_count",
-            "raw_date": "date"},
-        inplace=True,
-    )
-    route_daily_hourly_summary.date = route_daily_hourly_summary.date.dt.date
-    if save:
-        route_daily_hourly_summary.to_csv(
-            f"s3://{BUCKET}/schedule_summaries/route_level"
-            f"/schedule_route_daily_hourly_summary_v{VERSION_ID}.csv",
-            index=False,
+    if hourly:
+        groupby_vars.append("arrival_hour")
+        # group to get trips by hour by date by route
+        route_daily_summary = group_trips(
+            trip_summary,
+            groupby_vars=groupby_vars,
+            hourly=hourly
         )
 
-    # now group to get trips by hour by date by route by *direction*
-    route_dir_daily_hourly_summary = (
-        trip_summary.groupby(
-            by=["raw_date", "route_id",
-                "direction", "arrival_hour"])["trip_id"]
-        .count()
-        .reset_index()
-    )
+        if save:
+            route_daily_summary.to_csv(
+                f"s3://{BUCKET}/schedule_summaries/route_level"
+                f"/schedule_route_daily_hourly_summary_v{VERSION_ID}.csv",
+                index=False,
+            )
 
-    route_dir_daily_hourly_summary.rename(
-        columns={
-            "arrival_hour": "hour",
-            "trip_id": "trip_count",
-            "raw_date": "date"},
-        inplace=True,
-    )
-    route_dir_daily_hourly_summary.date = (
-        route_dir_daily_hourly_summary
-        .date.dt.date
-    )
-    if save:
-        route_dir_daily_hourly_summary.to_csv(
-            f"s3://{BUCKET}/schedule_summaries/route_dir_level/"
-            f"schedule_route_dir_daily_hourly_summary_v{VERSION_ID}.csv",
-            index=False,
+        # group to get trips by hour by date by route by *direction*
+        groupby_vars.append("direction")
+        route_dir_daily_summary = group_trips(
+            trip_summary,
+            groupby_vars=groupby_vars,
+            hourly=hourly
         )
-    return route_dir_daily_hourly_summary
+
+        if save:
+            route_dir_daily_summary.to_csv(
+                f"s3://{BUCKET}/schedule_summaries/route_dir_level/"
+                f"schedule_route_dir_daily_hourly_summary_v{VERSION_ID}.csv",
+                index=False,
+            )
+
+    else:
+        route_daily_summary = group_trips(
+            trip_summary,
+            groupby_vars=groupby_vars,
+            hourly=hourly
+        )
+
+        groupby_vars.append("direction")
+        route_dir_daily_summary = group_trips(
+            trip_summary,
+            groupby_vars=groupby_vars,
+            hourly=hourly
+        )
+
+        return route_daily_summary
 
 
 def make_linestring_of_points(
@@ -310,20 +341,34 @@ def make_linestring_of_points(
     return shapely.geometry.LineString(list(sorted_df["pt"]))
 
 
-def main() -> None:
-    """Download data from CTA, construct shapes from shape data,
-    and save to geojson file
+def download_zip(version_id: str) -> zipfile.ZipFile:
+    """Download a version schedule from transitfeeds.com
+
+    Args:
+        version_id (str): The version schedule in the form
+            of a date e.g. YYYYMMDD
+
+    Returns:
+        zipfile.ZipFile: A zipfile for the CTA version id.
     """
     logger.info('Downloading CTA data')
     CTA_GTFS = zipfile.ZipFile(
         BytesIO(
             requests.get(
                 f"https://transitfeeds.com/p/chicago-transit-authority"
-                f"/165/{VERSION_ID}/download"
+                f"/165/{version_id}/download"
             ).content
         )
     )
     logging.info('Download complete')
+    return CTA_GTFS
+
+
+def main() -> None:
+    """Download data from CTA, construct shapes from shape data,
+    and save to geojson file
+    """
+    CTA_GTFS = download_zip(VERSION_ID)
     data = GTFSFeed.extract_data(CTA_GTFS)
     data = format_dates_hours(data)
 


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description

This pull request adds the option of resampling by various [frequencies](https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases). This will enable different ways of aggregating the data for the study of trends over time. It might also help in understanding why some routes have completed to scheduled trip ratios greater than 1 (#19).

Resolves #12 

## Type of change

- [ ] Bug fix
- [x] New functionality
- [ ] Documentation

## How has this been tested?
### Informal test

Daily aggregation using the string 'D' in Pandas [resampling](https://pandas.pydata.org/docs/user_guide/timeseries.html#offset-aliases) equals the original `groupby` method
```python
In [58]: orig = rt.groupby(by=['date', 'route_id'])['trip_count'].sum().reset_index()

In [59]: new = (rt.set_index(['date', 'route_id'])
    ...:             .groupby(
    ...:                 [pd.Grouper(level='date', freq='D'),
    ...:                  pd.Grouper(level='route_id')])['trip_count']
    ...:             .sum().reset_index()
    ...:         )

In [60]: orig.equals(new)
Out[60]: True
```

### Findings
Some findings from the reaggregated data

```python
schedule_feeds = [
        {
            "schedule_version": "20220507",
            "feed_start_date": "2022-05-20",
            "feed_end_date": "2022-06-02",
        },
        {
            "schedule_version": "20220603",
            "feed_start_date": "2022-06-04",
            "feed_end_date": "2022-06-07",
        },
        {
            "schedule_version": "20220608",
            "feed_start_date": "2022-06-09",
            "feed_end_date": "2022-07-08",
        },
        {
            "schedule_version": "20220709",
            "feed_start_date": "2022-07-10",
            "feed_end_date": "2022-07-17",
        },
        {
            "schedule_version": "20220718",
            "feed_start_date": "2022-07-19",
            "feed_end_date": "2022-07-20",
        },
    ]
```


```python
In [15]: daily_info = AggInfo(freq='D')

In [16]: weekly_info = AggInfo(freq='W-MON')

In [17]: monthly_info = AggInfo(freq='M')

In [18]: output_list = []

In [19]: for info in [daily_info, weekly_info, monthly_info]:
    ...:     output_list.append(combine_real_time_rt_comparison(schedule_feeds, agg_info=info, save=Fa
    ...: lse))
    ...: 
100%|█████████████████████████████████████████████████████████████████| 14/14 [00:04<00:00,  3.39it/s]
INFO:root:Processing 20220507█████████████████████████████████████████| 14/14 [00:04<00:00,  3.04it/s]
100%|███████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  3.13it/s]
INFO:root:Processing 20220603███████████████████████████████████████████| 4/4 [00:01<00:00,  3.08it/s]
100%|█████████████████████████████████████████████████████████████████| 30/30 [00:08<00:00,  3.35it/s]
INFO:root:Processing 20220608█████████████████████████████████████████| 30/30 [00:08<00:00,  2.40it/s]
100%|███████████████████████████████████████████████████████████████████| 8/8 [00:02<00:00,  3.81it/s]
INFO:root:Processing 20220709███████████████████████████████████████████| 8/8 [00:02<00:00,  3.90it/s]
100%|███████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.20it/s]
INFO:root:Processing 20220718███████████████████████████████████████████| 2/2 [00:00<00:00,  3.13it/s]
Processing 2022-07-20 at2022-09-19 15:23:48: 100%|██████████████████████| 5/5 [00:22<00:00,  4.43s/it]
100%|█████████████████████████████████████████████████████████████████| 14/14 [00:03<00:00,  4.05it/s]
INFO:root:Processing 20220507█████████████████████████████████████████| 14/14 [00:03<00:00,  3.87it/s]
100%|███████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  4.36it/s]
INFO:root:Processing 20220603███████████████████████████████████████████| 4/4 [00:00<00:00,  4.24it/s]
100%|█████████████████████████████████████████████████████████████████| 30/30 [00:08<00:00,  3.64it/s]
INFO:root:Processing 20220608█████████████████████████████████████████| 30/30 [00:08<00:00,  3.58it/s]
100%|███████████████████████████████████████████████████████████████████| 8/8 [00:02<00:00,  3.87it/s]
INFO:root:Processing 20220709███████████████████████████████████████████| 8/8 [00:02<00:00,  4.13it/s]
100%|███████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.30it/s]
INFO:root:Processing 20220718███████████████████████████████████████████| 2/2 [00:00<00:00,  3.28it/s]
Processing 2022-07-20 at2022-09-19 15:24:08: 100%|██████████████████████| 5/5 [00:19<00:00,  3.98s/it]
100%|█████████████████████████████████████████████████████████████████| 14/14 [00:03<00:00,  4.46it/s]
INFO:root:Processing 20220507█████████████████████████████████████████| 14/14 [00:03<00:00,  4.26it/s]
100%|███████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  4.46it/s]
INFO:root:Processing 20220603███████████████████████████████████████████| 4/4 [00:00<00:00,  4.31it/s]
100%|█████████████████████████████████████████████████████████████████| 30/30 [00:06<00:00,  4.31it/s]
INFO:root:Processing 20220608█████████████████████████████████████████| 30/30 [00:06<00:00,  3.87it/s]
100%|███████████████████████████████████████████████████████████████████| 8/8 [00:01<00:00,  4.10it/s]
INFO:root:Processing 20220709███████████████████████████████████████████| 8/8 [00:01<00:00,  4.52it/s]
100%|███████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.71it/s]
INFO:root:Processing 20220718███████████████████████████████████████████| 2/2 [00:00<00:00,  3.64it/s]
Processing 2022-07-20 at2022-09-19 15:24:25: 100%|██████████████████████| 5/5 [00:17<00:00,  3.54s/it]
```

Here are the distributions of `ratio` in the combined DataFrame of the various schedule versions.

```python
# Daily
In [22]: for df in output_list:
    ...:     print(df.ratio.describe())
    ...: 
count    1530.000000
mean        0.806123
std         0.142894
min         0.210526
25%         0.705431
50%         0.809052
75%         0.916225
max         1.225806
Name: ratio, dtype: float64

# Weekly
count    738.000000
mean       0.493180
std        0.228549
min        0.096552
25%        0.278797
50%        0.477403
75%        0.662779
max        1.051724
Name: ratio, dtype: float64

# Monthly
count    861.000000
mean       0.242437
std        0.205531
min        0.042088
25%        0.101590
50%        0.188032
75%        0.261278
max        0.920404
Name: ratio, dtype: float64
```

And the summary across all schedule versions

```python
In [23]: summary_output = []

In [24]: for o in output_list:
    ...:     summary_output.append(build_summary(o, save=False))
    ...: 

In [25]: for df in summary_output:
    ...:     print(df.ratio.describe())
    ...: 
# Daily
count    423.000000
mean       0.799969
std        0.134382
min        0.210526
25%        0.711802
50%        0.798822
75%        0.901876
max        1.134615
Name: ratio, dtype: float64

# Weekly
count    246.000000
mean       0.655958
std        0.196121
min        0.289908
25%        0.486671
50%        0.593121
75%        0.824934
max        1.051724
Name: ratio, dtype: float64

# Monthly
count    369.000000
mean       0.249274
std        0.058417
min        0.118730
25%        0.204863
50%        0.247737
75%        0.292998
max        0.406403
Name: ratio, dtype: float64
```
#### Observations

For the monthly aggregation, the max `ratio` in the summary across schedule versions is notably lower than the max `ratio` of the combined individual schedules e.g. 0.41 vs 0.92.  

The median `ratio` in the summary across schedule versions drops from 0.8 in the daily aggregation to 0.59 in the weekly aggregation and 0.25 in the monthly aggregation.

`ratio` > 1 remains in the aggregations except for the monthly aggregation.

The routes with `ratio` > 1 are mostly on weekends and holidays.

```python
In [30]: for s in summary_output:
    ...:     print(s.day_type.loc[s.ratio > 1].value_counts(normalize=True))
    ...: 
# Daily
hol    0.380952
sun    0.285714
wk     0.190476
sat    0.142857
Name: day_type, dtype: float64

# Weekly
hol    1.0
Name: day_type, dtype: float64

# Monthly
Series([], Name: day_type, dtype: float64)
```

The weekday percentage of `ratio` > 1 is slightly higher for the individual schedule versions but still in the minority.

```python
In [31]: for o in output_list:
    ...:     print(o.day_type.loc[o.ratio > 1].value_counts(normalize=True))
    ...: 
# Daily
wk     0.320388
sun    0.291262
sat    0.223301
hol    0.165049
Name: day_type, dtype: float64

# Weekly
hol    1.0
Name: day_type, dtype: float64

# Monthly
Series([], Name: day_type, dtype: float64)
```

In each of the aggregations in the summary across schedule versions, the proportion of rows with `ratio` > 1 is less than 5 percent.

```python
In [32]: for s in summary_output:
    ...:     print((s.ratio > 1).sum() / len(s))
    ...: 
# Daily
0.04964539007092199

# Weekly
0.028455284552845527

# Monthly
0.0
```

In the aggregations of individual schedule versions, the proportion is less than 7 percent.
```python
In [33]: for o in output_list:
    ...:     print((o.ratio > 1).sum() / len(o))
    ...: 
# Daily
0.0673202614379085

# Weekly
0.009485094850948509

# Monthly
0.0
``` 