### PR TITLE
fix indent that was messing up loop

### DIFF
--- a/scrape_data/combine_daily_files.py
+++ b/scrape_data/combine_daily_files.py
@@ -71,8 +71,8 @@ def combine_daily_files(date: str):
                 new_data["scrape_file"] = obj_name
                 new_errors["scrape_file"] = obj_name
 
-                data_list.append(new_data)
-                errors_list.append(new_errors)
+            data_list.append(new_data)
+            errors_list.append(new_errors)
 
         data = pd.concat(data_list, ignore_index=True)
         errors = pd.concat(errors_list, ignore_index=True)


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description
Fix-it PR following #11 because one of the loops was wrong. After this merges we can *actually* do #17.

Resolves: An issue where all the files were wayyyyyy too big because each JSON "chunk" was being added multiple times. 

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Documentation

## How has this been tested? 
Tested locally. 
