### PR TITLE
Pre-commit hooks with linting and sorted imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+# Taken from https://towardsdatascience.com/pre-commit-hooks-you-must-know-ff247f5feb7e
+# Apply to all files without commiting:
+#   pre-commit run --all-files
+# Update this file:
+#   pre-commit autoupdate
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-ast
+    -   id: check-byte-order-marker
+    -   id: check-case-conflict
+    -   id: check-docstring-first
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: detect-aws-credentials
+    -   id: detect-private-key
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: mixed-line-ending
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    -   id: mypy
+        args: [--ignore-missing-imports]
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v2.2.0
+    hooks:
+    -   id: seed-isort-config
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.12.1
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies: [black==20.8b1]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ BUCKET_PRIVATE='chn-ghost-buses-private'
 Note that there may be permissions issues when running `rt_daily_aggregations.py` with `BUCKET_PUBLIC` as the `BUCKET_NAME`.
 
 ## Pre-commit hooks
-Pre-commit hooks are defined in `.pre-commit-config.yaml`. The hooks will enforce style with the linter `black`, check for commited credentials and extraneous debugger breakpoints, and sort imports, among other things.
+Pre-commit hooks are defined in `.pre-commit-config.yaml`, based on this [post](https://towardsdatascience.com/pre-commit-hooks-you-must-know-ff247f5feb7e). The hooks will enforce style with the linter `black`, check for commited credentials and extraneous debugger breakpoints, and sort imports, among other things.
 
 To get the latest versions of dependencies, update the `.pre-commit-config.yaml` file with `pre-commit autoupdate`. To run the hooks against all files without committing, use `pre-commit run --all-files`. To have the pre-commit hooks run when executing `git commit`, use `pre-commit install`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the repo for the [Chi Hack Night Ghost Buses breakout group](https://github.com/chihacknight/breakout-groups/issues/217)! If you're interested in working on it, you're invited to join the breakout group by [attending Chi Hack Night](https://chihacknight.org/).
 
-## AWS architecture 
+## AWS architecture
 __Updated May 19, 2022__
 
 Currently, the AWS setup is based on [this post](https://towardsdatascience.com/serverless-covid-19-data-scraper-with-python-and-aws-lambda-d6789a551b78) with some references to the [CPS Covid Dashboard back-end](https://github.com/misterjacko/CPS-COVID-BE).
@@ -10,11 +10,16 @@ Currently, the AWS setup is based on [this post](https://towardsdatascience.com/
 TODO: Describe how to make updates to the code in AWS
 
 ## Getting started
-Set up a virtual environment with `python3 -m venv .venv` and activate it with `source .venv/bin/activate` (`.venv\Scripts\activate` in Windows). Then run `pip install -r requirements.txt` to install the required packages. 
+Set up a virtual environment with `python3 -m venv .venv` and activate it with `source .venv/bin/activate` (`.venv\Scripts\activate` in Windows). Then run `pip install -r requirements.txt` to install the required packages.
 
 To set environment variables, create a `.env` file in the top-level directory and add the following contents:
 ```
 BUCKET_PUBLIC='chn-ghost-buses-public'
 BUCKET_PRIVATE='chn-ghost-buses-private'
 ```
-Note that there may be permissions issues when running `rt_daily_aggregations.py` with `BUCKET_PUBLIC` as the `BUCKET_NAME`. 
+Note that there may be permissions issues when running `rt_daily_aggregations.py` with `BUCKET_PUBLIC` as the `BUCKET_NAME`.
+
+## Pre-commit hooks
+Pre-commit hooks are defined in `.pre-commit-config.yaml`. The hooks will enforce style with the linter `black`, check for commited credentials and extraneous debugger breakpoints, and sort imports, among other things.
+
+To get the latest versions of dependencies, update the `.pre-commit-config.yaml` file with `pre-commit autoupdate`. To run the hooks against all files without committing, use `pre-commit run --all-files`. To have the pre-commit hooks run when executing `git commit`, use `pre-commit install`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ folium==0.12.1.post1
 mapclassify==2.4.2+55.g0155c6e
 plotly==5.11.0
 kaleido==0.2.1
-
+pre-commit==2.20.0


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description

Adding pre-commit hooks that have linting, sorting of imports, type checking, and checks for committed credentials and extraneous debugger breakpoints, among other things. 

Resolves #32 

## Type of change

- [ ] Bug fix
- [x] New functionality
- [ ] Documentation

## How has this been tested?
Locally