### PR TITLE
Use full s3 URL for ConnectionTimeoutError

### DIFF
--- a/data_analysis/compare_scheduled_and_rt.py
+++ b/data_analysis/compare_scheduled_and_rt.py
@@ -242,7 +242,7 @@ def combine_real_time_rt_comparison(
                 )
             except (botocore.exceptions.ConnectTimeoutError, botocore.exceptions.EndpointConnectionError):
                 daily_data = pd.read_csv(
-                    f'https://chn-ghost-buses-public.s3.us-east-2.amazonaws.com/bus_full_day_data_v2/{date_str}.csv',
+                    f'https://{BUCKET_PUBLIC}.s3.us-east-2.amazonaws.com/bus_full_day_data_v2/{date_str}.csv',
                     low_memory=False
                 )
 

--- a/scrape_data/cta_data_downloads.py
+++ b/scrape_data/cta_data_downloads.py
@@ -1,11 +1,13 @@
 import boto3
 import sys
-import data_analysis.static_gtfs_analysis as sga
-import data_analysis.compare_scheduled_and_rt as csrt
+
 import pendulum
 from io import StringIO
 import pandas as pd
-import botocore
+
+import data_analysis.static_gtfs_analysis as sga
+import data_analysis.compare_scheduled_and_rt as csrt
+from utils import s3_csv_reader
 
 ACCESS_KEY = sys.argv[1]
 SECRET_KEY = sys.argv[2]
@@ -89,18 +91,8 @@ def save_realtime_daily_summary() -> None:
     
     end_date = end_date.to_date_string()
 
-    try:
-        daily_data = pd.read_csv(
-                (csrt.BASE_PATH / f"bus_full_day_data_v2/{end_date}.csv")
-                .as_uri(),
-                low_memory=False
-            )
-    except (botocore.exceptions.ConnectTimeoutError, botocore.exceptions.EndpointConnectionError):
-        daily_data = pd.read_csv(
-            f'https://{csrt.BUCKET_PUBLIC}.s3.us-east-2.amazonaws.com/bus_full_day_data_v2/{end_date}.csv',
-            low_memory=False
-        )
-
+    daily_data = s3_csv_reader.read_csv(csrt.BASE_PATH / f"bus_full_day_data_v2/{end_date}.csv")
+    
     daily_data = csrt.make_daily_summary(daily_data)
     filename = f'realtime_summaries/daily_job/bus_full_day_data_v2/{end_date}.csv'
     save_csv_to_bucket(daily_data, filename=filename)

--- a/utils/s3_csv_reader.py
+++ b/utils/s3_csv_reader.py
@@ -1,10 +1,9 @@
 import pandas as pd
 from pathlib import Path
-import botocore
 import data_analysis.compare_scheduled_and_rt as csrt
 
 def read_csv(filename: str | Path) -> pd.DataFrame:    
-    """Read pandas csv from S3 using multiple methods
+    """Read pandas csv from S3
 
     Args:
         filename (str | Path): file to download from S3.
@@ -14,13 +13,10 @@ def read_csv(filename: str | Path) -> pd.DataFrame:
     """
     if isinstance(filename, str):
         filename = Path(filename)
-    # Use low_memory option to avoid warning about columns with mixed dtypes.
-    try:
-        df = pd.read_csv(filename.as_uri(), low_memory=False)
-    except (botocore.exceptions.ConnectTimeoutError, botocore.exceptions.EndpointConnectionError):
-        s3_filename = '/'.join(filename.parts[-2:])
-        df = pd.read_csv(
+    s3_filename = '/'.join(filename.parts[-2:])
+    df = pd.read_csv(
             f'https://{csrt.BUCKET_PUBLIC}.s3.us-east-2.amazonaws.com/{s3_filename}',
             low_memory=False
         )
     return df
+    

--- a/utils/s3_csv_reader.py
+++ b/utils/s3_csv_reader.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from pathlib import Path
+import botocore
+import data_analysis.compare_scheduled_and_rt as csrt
+
+def read_csv(filename: str | Path) -> pd.DataFrame:    
+    """Read pandas csv from S3 using multiple methods
+
+    Args:
+        filename (str | Path): file to download from S3.
+
+    Returns:
+        pd.DataFrame: A Pandas DataFrame from the S3 file.
+    """
+    if isinstance(filename, str):
+        filename = Path(filename)
+    # Use low_memory option to avoid warning about columns with mixed dtypes.
+    try:
+        df = pd.read_csv(filename.as_uri(), low_memory=False)
+    except (botocore.exceptions.ConnectTimeoutError, botocore.exceptions.EndpointConnectionError):
+        s3_filename = '/'.join(filename.parts[-2:])
+        df = pd.read_csv(
+            f'https://{csrt.BUCKET_PUBLIC}.s3.us-east-2.amazonaws.com/{s3_filename}',
+            low_memory=False
+        )
+    return df


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description

[Line 235](https://github.com/chihacknight/chn-ghost-buses/blob/main/data_analysis/compare_scheduled_and_rt.py#L235) of `compare_scheduled_and_rt.py` throws a `botocore.exceptions.ConnectionTimeoutError` or a `botocore.exceptions.EndpointConnectionError`. Using the `s3` URL gets around this problem.

Resolves #59 

## Type of change

- [x] Bug fix
- [ ] New functionality
- [ ] Documentation

## How has this been tested?
Locally