### PR TITLE
bump mapclassify version to fix github action

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ python-dotenv==0.20.0
 seaborn==0.12.0
 PyQt5>=5.15.7
 folium==0.12.1.post1
-mapclassify>=2.4.2+55.g0155c6e
+mapclassify>=2.5.0
 plotly==5.11.0
 kaleido==0.2.1
 pre-commit==2.20.0


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description

Please describe your changes, why you're making them, and any other context that someone would need to review this pull request.

Not clear to me why this started failing now, but [it did](https://github.com/chihacknight/chn-ghost-buses/actions/runs/9617529539/job/26529463480). Bumping mapclassify to a later version (looks like the GHA is actually installing 2.6.1 but I figured I'd do the earliest major version after what we currently had)

Resolves # [issue]

## Type of change

- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation

## How has this been tested?
