### PR TITLE
allow manual trigger of schedule download

### DIFF
--- a/.github/workflows/cta_data_downloads.yml
+++ b/.github/workflows/cta_data_downloads.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Run every day at 12:30pm CST which is 5:30pm UTC
     - cron: 30 17 * * * 
+  workflow_dispatch:
 
 env: 
   PYTHON_VERSION: 3.10.6


### PR DESCRIPTION
<!--- taken/adapted from the Cal-ITP data-infra repo: https://github.com/cal-itp/data-infra/blob/main/.github/pull_request_template.md --->

# Description

Please describe your changes, why you're making them, and any other context that someone would need to review this pull request.

Allow manual runs of GTFS schedule downloads to recover from failures as happened earlier today 

Resolves # [issue]

## Type of change

- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation

## How has this been tested?
